### PR TITLE
Tiled view: group/ungroup tiles, per-project and global sub-tabs control

### DIFF
--- a/src/main/session-store.ts
+++ b/src/main/session-store.ts
@@ -26,6 +26,7 @@ export interface Project {
   backend?: 'default' | 'claude' | 'gemini' | 'codex' | 'opencode' | 'aider' // Per-project backend (overrides global)
   categoryId?: string         // Category this project belongs to
   order?: number              // Order within category or uncategorized list
+  subTabsEnabled?: boolean    // Whether to group sessions into sub-tabs in tiled view (default: true)
 }
 
 export interface OpenTab {

--- a/src/main/session-store.ts
+++ b/src/main/session-store.ts
@@ -91,6 +91,7 @@ export interface Settings {
   autoAcceptTools?: string[]
   permissionMode?: string
   backend?: 'default' | 'claude' | 'gemini' | 'codex' | 'opencode' | 'aider'
+  subTabsEnabled?: boolean  // default: true
 }
 
 

--- a/src/renderer/App/MainApp.tsx
+++ b/src/renderer/App/MainApp.tsx
@@ -142,8 +142,9 @@ export function MainApp({ api, isElectron, onDisconnect }: MainAppProps): React.
 
   const handleGroupTile = useCallback((tileId: string, projectPath: string, containerSize: { width: number; height: number }) => {
     setTileLayout(groupProjectTiles(tileLayout, projectPath, openTabs, containerSize.width, containerSize.height))
-    updateProject(projectPath, { subTabsEnabled: undefined })
-  }, [tileLayout, openTabs, setTileLayout, updateProject])
+    const globalEnabled = settings?.subTabsEnabled !== false
+    updateProject(projectPath, { subTabsEnabled: globalEnabled ? undefined : true })
+  }, [tileLayout, openTabs, setTileLayout, updateProject, settings])
 
   // App-specific state
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false)
@@ -364,6 +365,7 @@ export function MainApp({ api, isElectron, onDisconnect }: MainAppProps): React.
                       onUngroupTile={handleUngroupTile}
                       onGroupTile={handleGroupTile}
                       onUndoCloseTab={canUndoCloseTab ? handleUndoCloseTab : undefined}
+                      globalSubTabsEnabled={settings?.subTabsEnabled !== false}
                       api={api}
                     />
                   </ErrorBoundary>

--- a/src/renderer/App/MainApp.tsx
+++ b/src/renderer/App/MainApp.tsx
@@ -3,7 +3,7 @@ import { TitleBar } from '../components/TitleBar'
 import { Sidebar } from '../components/Sidebar'
 import { TerminalTabs } from '../components/TerminalTabs'
 import { Terminal } from '../components/terminal/Terminal'
-import { TiledTerminalView } from '../components/TiledTerminalView'
+import { TiledTerminalView, ungroupTileLayout, groupProjectTiles } from '../components/TiledTerminalView'
 import { SettingsModal } from '../components/SettingsModal'
 import { MakeProjectModal } from '../components/MakeProjectModal'
 import { ErrorBoundary } from '../components/ErrorBoundary'
@@ -134,6 +134,16 @@ export function MainApp({ api, isElectron, onDisconnect }: MainAppProps): React.
     setActiveTab,
     setTileLayout
   })
+
+  const handleUngroupTile = useCallback((tileId: string, projectPath: string, containerSize: { width: number; height: number }) => {
+    setTileLayout(ungroupTileLayout(tileLayout, tileId, containerSize.width, containerSize.height))
+    updateProject(projectPath, { subTabsEnabled: false })
+  }, [tileLayout, setTileLayout, updateProject])
+
+  const handleGroupTile = useCallback((tileId: string, projectPath: string, containerSize: { width: number; height: number }) => {
+    setTileLayout(groupProjectTiles(tileLayout, projectPath, openTabs, containerSize.width, containerSize.height))
+    updateProject(projectPath, { subTabsEnabled: undefined })
+  }, [tileLayout, openTabs, setTileLayout, updateProject])
 
   // App-specific state
   const [mobileDrawerOpen, setMobileDrawerOpen] = useState(false)
@@ -351,6 +361,8 @@ export function MainApp({ api, isElectron, onDisconnect }: MainAppProps): React.
                       onLayoutChange={setTileLayout}
                       onOpenSessionAtPosition={handleOpenSessionAtPosition}
                       onAddTab={(projectPath) => handleOpenSession(projectPath, undefined, undefined, undefined, true)}
+                      onUngroupTile={handleUngroupTile}
+                      onGroupTile={handleGroupTile}
                       onUndoCloseTab={canUndoCloseTab ? handleUndoCloseTab : undefined}
                       api={api}
                     />

--- a/src/renderer/api/types.ts
+++ b/src/renderer/api/types.ts
@@ -61,6 +61,7 @@ export interface Settings {
   autoAcceptTools?: string[]
   permissionMode?: string
   backend?: BackendSelection
+  subTabsEnabled?: boolean
 }
 
 /**

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -113,7 +113,8 @@ export function SettingsModal({
           themeCustomization: migrateThemeCustomization(settings.themeCustomization),
           autoAcceptTools: settings.autoAcceptTools || [],
           permissionMode: settings.permissionMode || 'default',
-          backend: settings.backend || 'default'
+          backend: settings.backend || 'default',
+          subTabsEnabled: settings.subTabsEnabled !== false
         }))
       })
 
@@ -162,7 +163,8 @@ export function SettingsModal({
       themeCustomization: general.themeCustomization,
       autoAcceptTools: general.autoAcceptTools,
       permissionMode: general.permissionMode,
-      backend: general.backend
+      backend: general.backend,
+      subTabsEnabled: general.subTabsEnabled
     }
     await window.electronAPI?.saveSettings(newSettings)
     // Save voice settings including XTTS quality settings
@@ -308,6 +310,20 @@ export function SettingsModal({
             backend={general.backend}
             onChange={(backend) => setGeneral(prev => ({ ...prev, backend }))}
           />
+
+          <div className="settings-section">
+            <h3>Tiled View</h3>
+            <div className="form-group">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={general.subTabsEnabled}
+                  onChange={(e) => setGeneral(prev => ({ ...prev, subTabsEnabled: e.target.checked }))}
+                />
+                <span>Group sessions from the same project into sub-tabs by default</span>
+              </label>
+            </div>
+          </div>
 
           <ExtensionsSettings installedExtensions={installedExtensions} />
 

--- a/src/renderer/components/TerminalTabs.tsx
+++ b/src/renderer/components/TerminalTabs.tsx
@@ -43,7 +43,16 @@ const TabItem = memo(function TabItem({ tab, isActive, onSelect, onClose, onNewS
       onClick={handleClick}
       onKeyDown={handleKeyDown}
     >
-      <span className="tab-title" title={tab.title}>{tab.title}</span>
+      <span className="tab-title" title={tab.title}>
+        {(() => {
+          const projectFolder = tab.projectPath.split(/[/\\]/).pop() || ''
+          const prefix = projectFolder + ' - '
+          if (tab.title.startsWith(prefix)) {
+            return <><strong>{projectFolder}</strong>{' - ' + tab.title.slice(prefix.length)}</>
+          }
+          return tab.title
+        })()}
+      </span>
       <button
         className="tab-new-session"
         onClick={handleNewSession}

--- a/src/renderer/components/settings/settingsTypes.ts
+++ b/src/renderer/components/settings/settingsTypes.ts
@@ -89,6 +89,7 @@ export interface GeneralSettings {
   permissionMode: string
   customTool: string
   backend: 'default' | 'claude' | 'gemini' | 'codex' | 'opencode' | 'aider'
+  subTabsEnabled: boolean
 }
 
 export interface VoiceSettings {
@@ -125,7 +126,8 @@ export const DEFAULT_GENERAL: GeneralSettings = {
   autoAcceptTools: [],
   permissionMode: 'default',
   customTool: '',
-  backend: 'default'
+  backend: 'default',
+  subTabsEnabled: true
 }
 
 export const DEFAULT_VOICE: VoiceSettings = {
@@ -167,7 +169,7 @@ export interface SettingsModalProps {
   isOpen: boolean
   onClose: () => void
   onThemeChange: (theme: Theme) => void
-  onSaved?: (settings: { defaultProjectDir: string; theme: string; themeCustomization?: ThemeCustomization; autoAcceptTools?: string[]; permissionMode?: string; backend?: 'default' | 'claude' | 'gemini' | 'codex' | 'opencode' | 'aider' }) => void
+  onSaved?: (settings: { defaultProjectDir: string; theme: string; themeCustomization?: ThemeCustomization; autoAcceptTools?: string[]; permissionMode?: string; backend?: 'default' | 'claude' | 'gemini' | 'codex' | 'opencode' | 'aider'; subTabsEnabled?: boolean }) => void
   appVersion?: string
   updateStatus?: UpdateStatus
   onDownloadUpdate?: () => void

--- a/src/renderer/components/sidebar/ProjectSettingsModal.tsx
+++ b/src/renderer/components/sidebar/ProjectSettingsModal.tsx
@@ -279,6 +279,24 @@ export function ProjectSettingsModal({
               )}
             </div>
           </div>
+
+          {/* Tiled View Section */}
+          <div className="settings-section">
+            <h3>Tiled View</h3>
+            <div className="form-group">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={state.subTabsEnabled}
+                  onChange={(e) => onChange({ subTabsEnabled: e.target.checked })}
+                />
+                Group sessions from this project into sub-tabs
+              </label>
+              <p className="form-hint">
+                When enabled, opening multiple sessions from this project stacks them as sub-tabs within a single tile.
+              </p>
+            </div>
+          </div>
         </div>
         <div className="modal-footer">
           <button className="btn-secondary" onClick={onClose} disabled={state.apiStatus === 'checking'}>Cancel</button>

--- a/src/renderer/components/sidebar/ProjectSettingsModal.tsx
+++ b/src/renderer/components/sidebar/ProjectSettingsModal.tsx
@@ -6,6 +6,7 @@ import { COMMON_TOOLS, PERMISSION_MODES, API_SESSION_MODES, API_MODELS } from '.
 interface ProjectSettingsModalProps {
   state: ProjectSettingsModalState
   globalPermissions: { tools: string[]; mode: string }
+  globalSubTabsEnabled?: boolean
   globalVoiceSettings: { voice: string; engine: string }
   installedVoices: InstalledVoice[]
   onClose: () => void
@@ -19,6 +20,7 @@ interface ProjectSettingsModalProps {
 export function ProjectSettingsModal({
   state,
   globalPermissions,
+  globalSubTabsEnabled = true,
   globalVoiceSettings,
   installedVoices,
   onClose,
@@ -294,6 +296,9 @@ export function ProjectSettingsModal({
               </label>
               <p className="form-hint">
                 When enabled, opening multiple sessions from this project stacks them as sub-tabs within a single tile.
+              </p>
+              <p className="form-hint global-hint">
+                Global default: {globalSubTabsEnabled ? 'enabled' : 'disabled'}
               </p>
             </div>
           </div>

--- a/src/renderer/components/sidebar/SidebarContent.tsx
+++ b/src/renderer/components/sidebar/SidebarContent.tsx
@@ -99,6 +99,7 @@ export function SidebarContent(props: SidebarContentProps): React.ReactElement {
     moveProjectToCategory,
     removeCategory,
     globalPermissions,
+    globalSubTabsEnabled,
     globalVoiceSettings,
     installedVoices,
     handleOpenProjectSettings,
@@ -389,6 +390,7 @@ export function SidebarContent(props: SidebarContentProps): React.ReactElement {
         <ProjectSettingsModal
           state={projectSettingsModal}
           globalPermissions={globalPermissions}
+          globalSubTabsEnabled={globalSubTabsEnabled}
           globalVoiceSettings={globalVoiceSettings}
           installedVoices={installedVoices}
           onClose={() => setProjectSettingsModal(null)}

--- a/src/renderer/components/sidebar/hooks/useProjectSettingsModal.ts
+++ b/src/renderer/components/sidebar/hooks/useProjectSettingsModal.ts
@@ -91,6 +91,7 @@ export function useProjectSettingsModal({
       ttsVoice: project.ttsVoice || '',
       ttsEngine: project.ttsEngine || '',
       backend: project.backend || 'default',
+      subTabsEnabled: project.subTabsEnabled !== false,
     })
   }, [])
 
@@ -163,6 +164,7 @@ export function useProjectSettingsModal({
         projectSettingsModal.backend !== 'default'
           ? projectSettingsModal.backend
           : undefined,
+      subTabsEnabled: projectSettingsModal.subTabsEnabled ? undefined : false,
     })
 
     setProjectSettingsModal(null)

--- a/src/renderer/components/sidebar/hooks/useProjectSettingsModal.ts
+++ b/src/renderer/components/sidebar/hooks/useProjectSettingsModal.ts
@@ -12,6 +12,7 @@ interface UseProjectSettingsModalReturn {
   installedVoices: InstalledVoice[]
   globalVoiceSettings: { voice: string; engine: string }
   globalPermissions: { tools: string[]; mode: string }
+  globalSubTabsEnabled: boolean
   apiStatus: Record<string, { running: boolean; port?: number }>
   setApiStatus: React.Dispatch<
     React.SetStateAction<Record<string, { running: boolean; port?: number }>>
@@ -45,6 +46,7 @@ export function useProjectSettingsModal({
   const [apiStatus, setApiStatus] = useState<
     Record<string, { running: boolean; port?: number }>
   >({})
+  const [globalSubTabsEnabled, setGlobalSubTabsEnabled] = useState<boolean>(true)
 
   const handleOpenProjectSettings = useCallback(async (project: Project) => {
     const settings = await window.electronAPI?.getSettings()
@@ -52,6 +54,8 @@ export function useProjectSettingsModal({
       tools: settings?.autoAcceptTools || [],
       mode: settings?.permissionMode || 'default',
     })
+    const globalEnabled = settings?.subTabsEnabled !== false
+    setGlobalSubTabsEnabled(globalEnabled)
 
     try {
       const [piperVoices, xttsVoices, voiceSettings] = await Promise.all([
@@ -91,7 +95,9 @@ export function useProjectSettingsModal({
       ttsVoice: project.ttsVoice || '',
       ttsEngine: project.ttsEngine || '',
       backend: project.backend || 'default',
-      subTabsEnabled: project.subTabsEnabled !== false,
+      subTabsEnabled: project.subTabsEnabled !== undefined
+        ? project.subTabsEnabled
+        : globalEnabled,
     })
   }, [])
 
@@ -164,7 +170,9 @@ export function useProjectSettingsModal({
         projectSettingsModal.backend !== 'default'
           ? projectSettingsModal.backend
           : undefined,
-      subTabsEnabled: projectSettingsModal.subTabsEnabled ? undefined : false,
+      subTabsEnabled: projectSettingsModal.subTabsEnabled === globalSubTabsEnabled
+        ? undefined
+        : projectSettingsModal.subTabsEnabled,
     })
 
     setProjectSettingsModal(null)
@@ -228,6 +236,7 @@ export function useProjectSettingsModal({
     installedVoices,
     globalVoiceSettings,
     globalPermissions,
+    globalSubTabsEnabled,
     apiStatus,
     setApiStatus,
     handleOpenProjectSettings,

--- a/src/renderer/components/sidebar/types.ts
+++ b/src/renderer/components/sidebar/types.ts
@@ -56,6 +56,7 @@ export interface ProjectSettingsModalState {
   ttsVoice: string
   ttsEngine: 'piper' | 'xtts' | ''
   backend: 'default' | 'claude' | 'gemini' | 'codex' | 'opencode' | 'aider'
+  subTabsEnabled: boolean
 }
 
 export interface InstalledVoice {

--- a/src/renderer/components/sidebar/useSidebarState.ts
+++ b/src/renderer/components/sidebar/useSidebarState.ts
@@ -54,6 +54,7 @@ export interface SidebarState {
   installedVoices: ReturnType<typeof useProjectSettingsModal>['installedVoices']
   globalVoiceSettings: ReturnType<typeof useProjectSettingsModal>['globalVoiceSettings']
   globalPermissions: ReturnType<typeof useProjectSettingsModal>['globalPermissions']
+  globalSubTabsEnabled: ReturnType<typeof useProjectSettingsModal>['globalSubTabsEnabled']
   apiStatus: ReturnType<typeof useProjectSettingsModal>['apiStatus']
   setApiStatus: ReturnType<typeof useProjectSettingsModal>['setApiStatus']
   handleOpenProjectSettings: ReturnType<typeof useProjectSettingsModal>['handleOpenProjectSettings']
@@ -176,6 +177,7 @@ export function useSidebarState(params: UseSidebarStateParams): SidebarState {
     installedVoices,
     globalVoiceSettings,
     globalPermissions,
+    globalSubTabsEnabled,
     apiStatus,
     setApiStatus,
     handleOpenProjectSettings,
@@ -304,6 +306,7 @@ export function useSidebarState(params: UseSidebarStateParams): SidebarState {
     installedVoices,
     globalVoiceSettings,
     globalPermissions,
+    globalSubTabsEnabled,
     apiStatus,
     setApiStatus,
     handleOpenProjectSettings,

--- a/src/renderer/components/tiled-layout-utils.ts
+++ b/src/renderer/components/tiled-layout-utils.ts
@@ -511,6 +511,61 @@ export function removeTabFromTile(
   })
 }
 
+/** Group all tiles belonging to the same project into a single tile with sub-tabs */
+export function groupProjectTiles(
+  layout: TileLayout[],
+  projectPath: string,
+  tabs: OpenTab[],
+  containerWidth: number,
+  containerHeight: number
+): TileLayout[] {
+  const projectTiles = layout.filter(tile =>
+    tile.tabIds.some(tabId => tabs.find(t => t.id === tabId)?.projectPath === projectPath)
+  )
+  if (projectTiles.length <= 1) return layout
+
+  const firstTile = projectTiles[0]
+  const otherTileIds = projectTiles.slice(1).map(t => t.id)
+  const allTabIds = projectTiles.flatMap(t => t.tabIds)
+
+  let newLayout = layout.map(t =>
+    t.id === firstTile.id
+      ? { ...t, tabIds: allTabIds, activeTabId: allTabIds[allTabIds.length - 1] }
+      : t
+  )
+  for (const tileId of otherTileIds) {
+    newLayout = removeTilePreservingStructure(newLayout, tileId, tabs, containerWidth, containerHeight)
+  }
+  return newLayout
+}
+
+/** Ungroup all sub-tabs of a tile into separate independent tiles */
+export function ungroupTileLayout(
+  layout: TileLayout[],
+  tileId: string,
+  containerWidth: number,
+  containerHeight: number
+): TileLayout[] {
+  const tile = layout.find(t => t.id === tileId)
+  if (!tile || tile.tabIds.length <= 1) return layout
+
+  const [firstTabId, ...restTabIds] = tile.tabIds
+
+  // Keep first tab in the original tile space
+  let newLayout = layout.map(t =>
+    t.id === tileId
+      ? { ...t, tabIds: [firstTabId], activeTabId: firstTabId }
+      : t
+  )
+
+  // Add remaining tabs as new independent tiles
+  for (const tabId of restTabIds) {
+    newLayout = addTileToLayout(newLayout, tabId, null, containerWidth, containerHeight)
+  }
+
+  return newLayout
+}
+
 /** Get all tab IDs across all tiles */
 export function getAllTabIdsFromLayout(layout: TileLayout[]): Set<string> {
   const ids = new Set<string>()

--- a/src/renderer/components/tiled-layout-utils.ts
+++ b/src/renderer/components/tiled-layout-utils.ts
@@ -141,11 +141,13 @@ function makeTile(id: string, x: number, y: number, width: number, height: numbe
   return { id, tabIds: tIds, activeTabId: activeTabId || tIds[0], x, y, width, height }
 }
 
-export function generateDefaultLayout(tabs: OpenTab[], containerWidth = 1920, containerHeight = 1080): TileLayout[] {
-  // Group tabs by projectPath
+export function generateDefaultLayout(tabs: OpenTab[], containerWidth = 1920, containerHeight = 1080, disabledProjectPaths?: Set<string>): TileLayout[] {
+  // Group tabs by projectPath (or individually if project has sub-tabs disabled)
   const groups = new Map<string, OpenTab[]>()
   for (const tab of tabs) {
-    const key = tab.projectPath
+    const key = disabledProjectPaths?.has(tab.projectPath)
+      ? tab.id          // unique key per tab → its own group
+      : tab.projectPath // group by project
     const group = groups.get(key) || []
     group.push(tab)
     groups.set(key, group)

--- a/src/renderer/components/tiled/TileTerminal.tsx
+++ b/src/renderer/components/tiled/TileTerminal.tsx
@@ -27,6 +27,8 @@ interface TileTerminalProps {
   onFocusTab: (id: string) => void
   onSwitchSubTab: (tileId: string, tabId: string) => void
   onAddTab?: (projectPath: string) => void
+  onUngroupTile?: (tileId: string, projectPath: string, containerSize: { width: number; height: number }) => void
+  onGroupTile?: (tileId: string, projectPath: string, containerSize: { width: number; height: number }) => void
   onDragStart: (e: React.DragEvent, tileId: string) => void
   onDragEnd: () => void
   onContainerDrop: (e: React.DragEvent) => void
@@ -57,6 +59,8 @@ export function TileTerminal({
   onFocusTab,
   onSwitchSubTab,
   onAddTab,
+  onUngroupTile,
+  onGroupTile,
   onDragStart,
   onDragEnd,
   onContainerDrop,
@@ -89,6 +93,28 @@ export function TileTerminal({
       onAddTab(projectPath)
     }
   }, [tabs, onAddTab])
+
+  const handleUngroup = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
+    const projectPath = tabs[0]?.projectPath
+    if (projectPath && onUngroupTile) {
+      const rect = containerRef.current?.getBoundingClientRect()
+      const containerSize = rect ? { width: rect.width, height: rect.height } : { width: 1920, height: 1080 }
+      onUngroupTile(tile.id, projectPath, containerSize)
+    }
+  }, [tile.id, tabs, onUngroupTile, containerRef])
+
+  const handleGroup = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+    e.preventDefault()
+    const projectPath = tabs[0]?.projectPath
+    if (projectPath && onGroupTile) {
+      const rect = containerRef.current?.getBoundingClientRect()
+      const containerSize = rect ? { width: rect.width, height: rect.height } : { width: 1920, height: 1080 }
+      onGroupTile(tile.id, projectPath, containerSize)
+    }
+  }, [tile.id, tabs, onGroupTile, containerRef])
 
   function handleTileDragOver(e: React.DragEvent): void {
     const isSidebarDrag = e.dataTransfer.types.includes('application/x-sidebar-project')
@@ -190,6 +216,15 @@ export function TileTerminal({
                 title="New session"
               >+</button>
             )}
+            {onUngroupTile && (
+              <button
+                className="tile-ungroup"
+                draggable={false}
+                onClick={handleUngroup}
+                onMouseDown={(e) => e.stopPropagation()}
+                title="Ungroup into separate tiles"
+              >⊞</button>
+            )}
           </>
         ) : (
           <>
@@ -203,6 +238,15 @@ export function TileTerminal({
                   onMouseDown={(e) => e.stopPropagation()}
                   title="New session"
                 >+</button>
+              )}
+              {onGroupTile && project?.subTabsEnabled === false && (
+                <button
+                  className="tile-group"
+                  draggable={false}
+                  onClick={handleGroup}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  title="Group sessions into sub-tabs"
+                >⊟</button>
               )}
               <button
                 className="tile-close"

--- a/src/renderer/components/tiled/TileTerminal.tsx
+++ b/src/renderer/components/tiled/TileTerminal.tsx
@@ -189,23 +189,42 @@ export function TileTerminal({
       >
         {hasMultipleTabs ? (
           <>
-            <div className="tile-subtabs">
-              {tabs.map(tab => (
-                <div
-                  key={tab.id}
-                  className={`tile-subtab ${tab.id === activeSubTabId ? 'active' : ''}`}
-                  onClick={() => handleSubTabClick(tab.id)}
-                >
-                  <span className="subtab-title" title={tab.title}>{tab.title}</span>
-                  <button
-                    className="subtab-close"
-                    draggable={false}
-                    onClick={(e) => handleSubTabClose(e, tab.id)}
-                    onMouseDown={(e) => e.stopPropagation()}
-                    title="Close"
-                  >&times;</button>
-                </div>
-              ))}
+            <div className="tile-title-group">
+              {project?.name && (
+                <span className="tile-project-name">{project.name}</span>
+              )}
+              {onUngroupTile && (
+                <button
+                  className="tile-ungroup"
+                  draggable={false}
+                  onClick={handleUngroup}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  title="Ungroup into separate tiles"
+                >⊞</button>
+              )}
+              <div className="tile-subtabs">
+                {tabs.map(tab => {
+                  const projectFolder = tab.projectPath.split(/[/\\]/).pop() || ''
+                  const prefix = projectFolder + ' - '
+                  const sessionTitle = tab.title.startsWith(prefix) ? tab.title.slice(prefix.length) : tab.title
+                  return (
+                  <div
+                    key={tab.id}
+                    className={`tile-subtab ${tab.id === activeSubTabId ? 'active' : ''}`}
+                    onClick={() => handleSubTabClick(tab.id)}
+                  >
+                    <span className="subtab-title" title={tab.title}>{sessionTitle}</span>
+                    <button
+                      className="subtab-close"
+                      draggable={false}
+                      onClick={(e) => handleSubTabClose(e, tab.id)}
+                      onMouseDown={(e) => e.stopPropagation()}
+                      title="Close"
+                    >&times;</button>
+                  </div>
+                  )
+                })}
+              </div>
             </div>
             {onAddTab && (
               <button
@@ -216,28 +235,12 @@ export function TileTerminal({
                 title="New session"
               >+</button>
             )}
-            {onUngroupTile && (
-              <button
-                className="tile-ungroup"
-                draggable={false}
-                onClick={handleUngroup}
-                onMouseDown={(e) => e.stopPropagation()}
-                title="Ungroup into separate tiles"
-              >⊞</button>
-            )}
           </>
         ) : (
           <>
-            <span className="tile-title" title={activeTab?.title}>{activeTab?.title}</span>
-            <div className="tile-header-actions">
-              {onAddTab && (
-                <button
-                  className="tile-add-tab"
-                  draggable={false}
-                  onClick={handleAddTab}
-                  onMouseDown={(e) => e.stopPropagation()}
-                  title="New session"
-                >+</button>
+            <div className="tile-title-group">
+              {project?.name && (
+                <span className="tile-project-name">{project.name}</span>
               )}
               {onGroupTile && project?.subTabsEnabled === false && (
                 <button
@@ -247,6 +250,23 @@ export function TileTerminal({
                   onMouseDown={(e) => e.stopPropagation()}
                   title="Group sessions into sub-tabs"
                 >⊟</button>
+              )}
+              {activeTab && (() => {
+                const projectFolder = activeTab.projectPath.split(/[/\\]/).pop() || ''
+                const prefix = projectFolder + ' - '
+                const sessionTitle = activeTab.title.startsWith(prefix) ? activeTab.title.slice(prefix.length) : activeTab.title
+                return <span className="tile-session-name" title={activeTab.title}>{sessionTitle}</span>
+              })()}
+            </div>
+            <div className="tile-header-actions">
+              {onAddTab && (
+                <button
+                  className="tile-add-tab"
+                  draggable={false}
+                  onClick={handleAddTab}
+                  onMouseDown={(e) => e.stopPropagation()}
+                  title="New session"
+                >+</button>
               )}
               <button
                 className="tile-close"

--- a/src/renderer/components/tiled/index.tsx
+++ b/src/renderer/components/tiled/index.tsx
@@ -16,7 +16,7 @@ import { TileTerminal } from './TileTerminal.js'
 import { DropZoneOverlay } from './DropZoneOverlay.js'
 
 export type { TileLayout, DropZone } from '../tiled-layout-utils.js'
-export { splitTile, addTileToLayout, addTabToExistingTile, findTileForProject } from '../tiled-layout-utils.js'
+export { splitTile, addTileToLayout, addTabToExistingTile, findTileForProject, ungroupTileLayout, groupProjectTiles } from '../tiled-layout-utils.js'
 
 const GAP = 4
 
@@ -31,6 +31,8 @@ export function TiledTerminalView({
   onLayoutChange,
   onOpenSessionAtPosition,
   onAddTab,
+  onUngroupTile,
+  onGroupTile,
   onUndoCloseTab,
   api
 }: TiledTerminalViewProps): React.ReactElement | null {
@@ -185,6 +187,8 @@ export function TiledTerminalView({
             onFocusTab={onFocusTab}
             onSwitchSubTab={handleSwitchSubTab}
             onAddTab={onAddTab}
+            onUngroupTile={onUngroupTile}
+            onGroupTile={onGroupTile}
             onDragStart={handleDragStart}
             onDragEnd={handleDragEnd}
             onContainerDrop={handleContainerDrop}

--- a/src/renderer/components/tiled/index.tsx
+++ b/src/renderer/components/tiled/index.tsx
@@ -34,6 +34,7 @@ export function TiledTerminalView({
   onUngroupTile,
   onGroupTile,
   onUndoCloseTab,
+  globalSubTabsEnabled,
   api
 }: TiledTerminalViewProps): React.ReactElement | null {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -71,7 +72,7 @@ export function TiledTerminalView({
   const [hoveredEdge, setHoveredEdge] = useState<{ tileId: string; edge: string } | null>(null)
 
   const { effectiveLayout, effectiveLayoutRef } = useEffectiveLayout(
-    layout, tabs, projects, containerSizeRef, onLayoutChange
+    layout, tabs, projects, containerSizeRef, onLayoutChange, globalSubTabsEnabled
   )
 
   // Ctrl+Shift+T to undo close tab
@@ -163,6 +164,12 @@ export function TiledTerminalView({
           : tileTabs[0].id
 
         const project = projects.find(p => p.path === tileTabs[0].projectPath)
+        const effectiveProject = project ? {
+          ...project,
+          subTabsEnabled: project.subTabsEnabled !== undefined
+            ? project.subTabsEnabled
+            : (globalSubTabsEnabled ?? true)
+        } : project
         const isFocused = focusedTabId != null && tile.tabIds.includes(focusedTabId)
 
         return (
@@ -171,7 +178,7 @@ export function TiledTerminalView({
             tile={tile}
             tabs={tileTabs}
             activeSubTabId={activeSubTabId}
-            project={project}
+            project={effectiveProject}
             theme={theme}
             api={api}
             GAP={GAP}

--- a/src/renderer/components/tiled/index.tsx
+++ b/src/renderer/components/tiled/index.tsx
@@ -69,7 +69,7 @@ export function TiledTerminalView({
   const [hoveredEdge, setHoveredEdge] = useState<{ tileId: string; edge: string } | null>(null)
 
   const { effectiveLayout, effectiveLayoutRef } = useEffectiveLayout(
-    layout, tabs, containerSizeRef, onLayoutChange
+    layout, tabs, projects, containerSizeRef, onLayoutChange
   )
 
   // Ctrl+Shift+T to undo close tab

--- a/src/renderer/components/tiled/types.ts
+++ b/src/renderer/components/tiled/types.ts
@@ -25,6 +25,7 @@ export interface TiledTerminalViewProps {
   onUngroupTile?: (tileId: string, projectPath: string, containerSize: { width: number; height: number }) => void
   onGroupTile?: (tileId: string, projectPath: string, containerSize: { width: number; height: number }) => void
   onUndoCloseTab?: () => void
+  globalSubTabsEnabled?: boolean
   api?: Api
 }
 

--- a/src/renderer/components/tiled/types.ts
+++ b/src/renderer/components/tiled/types.ts
@@ -22,6 +22,8 @@ export interface TiledTerminalViewProps {
   onLayoutChange: (layout: TileLayout[]) => void
   onOpenSessionAtPosition?: (projectPath: string, dropZone: DropZone | null, containerSize: { width: number, height: number }) => void
   onAddTab?: (projectPath: string) => void
+  onUngroupTile?: (tileId: string, projectPath: string, containerSize: { width: number; height: number }) => void
+  onGroupTile?: (tileId: string, projectPath: string, containerSize: { width: number; height: number }) => void
   onUndoCloseTab?: () => void
   api?: Api
 }

--- a/src/renderer/components/tiled/types.ts
+++ b/src/renderer/components/tiled/types.ts
@@ -6,6 +6,7 @@ export interface Project {
   path: string
   name: string
   color?: string
+  subTabsEnabled?: boolean
 }
 
 export type { OpenTab }

--- a/src/renderer/components/tiled/useEffectiveLayout.ts
+++ b/src/renderer/components/tiled/useEffectiveLayout.ts
@@ -17,7 +17,8 @@ export function useEffectiveLayout(
   tabs: OpenTab[],
   projects: { path: string; subTabsEnabled?: boolean }[],
   containerSizeRef: MutableRefObject<{ width: number; height: number }>,
-  onLayoutChange: (layout: TileLayout[]) => void
+  onLayoutChange: (layout: TileLayout[]) => void,
+  globalSubTabsEnabled?: boolean
 ): {
   effectiveLayout: TileLayout[]
   effectiveLayoutRef: MutableRefObject<TileLayout[]>
@@ -29,8 +30,11 @@ export function useEffectiveLayout(
   const effectiveLayout = useMemo(() => {
     const { width, height } = containerSizeRef.current
 
+    const globalEnabled = globalSubTabsEnabled ?? true
     const disabledPaths = new Set(
-      projects.filter(p => p.subTabsEnabled === false).map(p => p.path)
+      projects
+        .filter(p => (p.subTabsEnabled !== undefined ? p.subTabsEnabled : globalEnabled) === false)
+        .map(p => p.path)
     )
 
     if (layout.length === 0) {
@@ -76,7 +80,7 @@ export function useEffectiveLayout(
     }
 
     return validateLayout(newLayout, tabs, width, height)
-  }, [layout, tabs, projects, containerSizeRef])
+  }, [layout, tabs, projects, containerSizeRef, globalSubTabsEnabled])
 
   effectiveLayoutRef.current = effectiveLayout
 

--- a/src/renderer/components/tiled/useEffectiveLayout.ts
+++ b/src/renderer/components/tiled/useEffectiveLayout.ts
@@ -15,6 +15,7 @@ import type { OpenTab } from './types.js'
 export function useEffectiveLayout(
   layout: TileLayout[],
   tabs: OpenTab[],
+  projects: { path: string; subTabsEnabled?: boolean }[],
   containerSizeRef: MutableRefObject<{ width: number; height: number }>,
   onLayoutChange: (layout: TileLayout[]) => void
 ): {
@@ -28,8 +29,12 @@ export function useEffectiveLayout(
   const effectiveLayout = useMemo(() => {
     const { width, height } = containerSizeRef.current
 
+    const disabledPaths = new Set(
+      projects.filter(p => p.subTabsEnabled === false).map(p => p.path)
+    )
+
     if (layout.length === 0) {
-      return generateDefaultLayout(tabs, width, height)
+      return generateDefaultLayout(tabs, width, height, disabledPaths)
     }
 
     // Ensure all tiles are migrated to the new format
@@ -53,7 +58,10 @@ export function useEffectiveLayout(
 
     // Add new tabs - group by project into existing tiles when possible
     for (const addedTab of addedTabs) {
-      const existingTile = findTileForProject(newLayout, tabs, addedTab.projectPath)
+      const isSubTabsEnabled = !disabledPaths.has(addedTab.projectPath)
+      const existingTile = isSubTabsEnabled
+        ? findTileForProject(newLayout, tabs, addedTab.projectPath)
+        : undefined
       if (existingTile) {
         newLayout = addTabToExistingTile(newLayout, existingTile.id, addedTab.id)
       } else {
@@ -68,7 +76,7 @@ export function useEffectiveLayout(
     }
 
     return validateLayout(newLayout, tabs, width, height)
-  }, [layout, tabs, containerSizeRef])
+  }, [layout, tabs, projects, containerSizeRef])
 
   effectiveLayoutRef.current = effectiveLayout
 

--- a/src/renderer/hooks/useProjectHandlers.ts
+++ b/src/renderer/hooks/useProjectHandlers.ts
@@ -130,9 +130,11 @@ export function useProjectHandlers({
       })
 
       // Check if there's already a tile for this project and add as sub-tab
-      const existingTile = findTileForProject(tileLayout, openTabs, projectPath)
-      if (existingTile) {
-        setTileLayout(addTabToExistingTile(tileLayout, existingTile.id, ptyId))
+      if (project?.subTabsEnabled !== false) {
+        const existingTile = findTileForProject(tileLayout, openTabs, projectPath)
+        if (existingTile) {
+          setTileLayout(addTabToExistingTile(tileLayout, existingTile.id, ptyId))
+        }
       }
 
       // If an initial prompt was provided, send it after a short delay
@@ -191,7 +193,7 @@ export function useProjectHandlers({
           return tab && tab.projectPath === projectPath
         })
 
-        if (targetHasSameProject && targetTile) {
+        if (targetHasSameProject && targetTile && project?.subTabsEnabled !== false) {
           console.log('[App] Adding as sub-tab to existing tile')
           newLayout = addTabToExistingTile(tileLayout, targetTile.id, ptyId)
         } else {

--- a/src/renderer/hooks/useSettings.ts
+++ b/src/renderer/hooks/useSettings.ts
@@ -26,6 +26,7 @@ export interface AppSettings {
   autoAcceptTools?: string[]
   permissionMode?: string
   backend?: 'default' | 'claude' | 'gemini' | 'codex' | 'opencode' | 'aider'
+  subTabsEnabled?: boolean
 }
 
 interface UseSettingsReturn {

--- a/src/renderer/stores/workspace.ts
+++ b/src/renderer/stores/workspace.ts
@@ -24,6 +24,7 @@ export interface Project {
   backend?: 'default' | 'claude' | 'gemini' | 'codex' | 'opencode' | 'aider'
   categoryId?: string
   order?: number
+  subTabsEnabled?: boolean
 }
 
 export interface OpenTab {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1208,6 +1208,49 @@ html, body, #root {
   flex-shrink: 0;
 }
 
+.tile-title-group {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden;
+  flex: 1;
+  min-width: 0;
+}
+
+.tile-title-group > .tile-subtabs {
+  flex: 0 0 auto;
+}
+
+.tile-project-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  flex-shrink: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.tile-title-group > .tile-project-name:first-child + .tile-ungroup + .tile-subtabs,
+.tile-title-group > .tile-project-name:first-child + .tile-subtabs,
+.tile-title-group > .tile-project-name:first-child + .tile-group + .tile-session-name,
+.tile-title-group > .tile-project-name:first-child + .tile-session-name {
+  border-left: 1px solid var(--border-subtle);
+  padding-left: 6px;
+  margin-left: 2px;
+}
+
+.tile-session-name {
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
 .tile-title {
   font-size: 13px;
   font-weight: 500;
@@ -1215,6 +1258,7 @@ html, body, #root {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  min-width: 0;
 }
 
 .tile-close {
@@ -1316,6 +1360,29 @@ html, body, #root {
 }
 
 .tile-add-tab:hover {
+  color: var(--text-primary);
+  background: var(--bg-elevated);
+}
+
+.tile-group,
+.tile-ungroup {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 14px;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: 4px;
+  transition: color var(--transition-fast), background var(--transition-fast);
+}
+
+.tile-group:hover,
+.tile-ungroup:hover {
   color: var(--text-primary);
   background: var(--bg-elevated);
 }


### PR DESCRIPTION
## Summary

This branch adds full control over sub-tab grouping behaviour in the tiled terminal view, across 4 commits:

### 1. Per-project sub-tabs toggle (`43c3e74`)
- New `subTabsEnabled` field on `Project` (stored in workspace)
- When `false`, each new session from that project gets its own independent tile instead of being stacked as a sub-tab
- Toggle exposed in Project Settings modal (Tiled View section)

### 2. Group button to re-merge tiles (`7d3a565`)
- Adds a **⊟ Group** button symmetric to the existing **⊞ Ungroup** button
- Appears on each tile when the project has `subTabsEnabled === false`
- Clicking it calls `groupProjectTiles()` to merge all tiles for the same project back into a single tile with sub-tabs, and resets `subTabsEnabled` to `undefined`
- New `groupProjectTiles()` utility in `tiled-layout-utils.ts`

### 3. Tile & tab header display improvements (`baf1367`)
- Project name shown **bold** in tiled tile headers (both single-tab and multi-tab)
- Session title prefix stripped in sub-tab labels (project name already visible in the header)
- Group/Ungroup buttons positioned between project name and session/sub-tab labels
- Project name also bolded in the non-tiled `TerminalTabs` bar

### 4. Global `subTabsEnabled` setting with per-project override (`e1eb7af`)
- New global setting `subTabsEnabled` (default: `true`) in the main Settings modal under a new "Tiled View" section
- Resolution: `project ?? global ?? true`
- Project Settings shows the **effective** value and a **"Global default: enabled/disabled"** hint
- `handleGroupTile` sets `subTabsEnabled: true` explicitly (not `undefined`) when global is `false`, preserving the grouped state

#### Override table

| Global | Project | Effective |
|--------|---------|-----------|
| `true` (default) | `undefined` | grouped |
| `true` | `false` | ungrouped |
| `true` | `true` | grouped |
| `false` | `undefined` | ungrouped |
| `false` | `true` | grouped |
| `false` | `false` | ungrouped |

## Test plan

- [ ] Default behaviour (global = `true`): all projects grouped as before
- [ ] Per-project toggle: disabling sub-tabs for a project splits sessions into separate tiles
- [ ] ⊞ Ungroup button appears on grouped tiles; ⊟ Group button appears on ungrouped tiles
- [ ] Re-grouping merges all tiles for the project back into one tile with sub-tabs
- [ ] Tile headers: project name is bold; sub-tab labels show only the session slug
- [ ] Global setting disabled: projects with no explicit override switch to separate tiles
- [ ] Project with explicit `subTabsEnabled: true` stays grouped even when global is `false`
- [ ] ⊟ Group button appears when global = `false` and project = `undefined`
- [ ] Clicking ⊟ when global = `false` stores `subTabsEnabled: true` explicitly on the project

🤖 Generated with [Claude Code](https://claude.com/claude-code)