### PR TITLE
fix: tiled layout bugs — split guard, drag gaps, validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out/
 *.log
 .DS_Store
 dist-build/
+.kspec/

--- a/src/renderer/components/tiled-layout-utils.ts
+++ b/src/renderer/components/tiled-layout-utils.ts
@@ -227,7 +227,7 @@ export function validateLayout(layout: TileLayout[], tabs: OpenTab[], containerW
   for (const tile of cleaned) {
     if (tile.x < 0 || tile.y < 0 ||
         tile.y + tile.height > 100.5 ||
-        tile.width < 5 || tile.height < 5) {
+        tile.width < MIN_SIZE || tile.height < MIN_SIZE) {
       console.warn('Detected out-of-bounds tile, resetting to default layout', tile)
       return generateDefaultLayout(tabs, containerWidth, containerHeight)
     }
@@ -241,12 +241,19 @@ export function validateLayout(layout: TileLayout[], tabs: OpenTab[], containerW
     }
   }
 
+  let hasOverlap = false
   for (let i = 0; i < cleaned.length; i++) {
     for (let j = i + 1; j < cleaned.length; j++) {
       if (tilesOverlap(cleaned[i], cleaned[j])) {
-        console.warn('Detected overlapping tiles:', cleaned[i], cleaned[j])
+        console.warn('Detected overlapping tiles, resetting to default layout:', cleaned[i], cleaned[j])
+        hasOverlap = true
+        break
       }
     }
+    if (hasOverlap) break
+  }
+  if (hasOverlap) {
+    return generateDefaultLayout(tabs, containerWidth, containerHeight)
   }
   return cleaned
 }
@@ -368,6 +375,11 @@ export function splitTile(
   if (!target) return layout
 
   const isHorizontal = direction === 'top' || direction === 'bottom'
+
+  // Guard: don't split if the resulting tiles would be below MIN_SIZE
+  const halfDimension = isHorizontal ? target.height / 2 : target.width / 2
+  if (halfDimension < MIN_SIZE) return layout
+
   const newLayout = layout.filter(t => t.id !== targetTileId)
 
   // The target tile keeps its tabIds; the new tile gets a single tab

--- a/src/renderer/components/tiled/useTileDragDrop.ts
+++ b/src/renderer/components/tiled/useTileDragDrop.ts
@@ -141,9 +141,9 @@ export function useApplyDropZone(
     }
 
     const direction = zone.type.replace('split-', '') as 'top' | 'bottom' | 'left' | 'right'
-    // For drag operations, just remove the tile without expanding neighbors.
-    // The tile is being moved, not deleted — expansion would distort the layout.
-    const withoutDragged = layout.filter(t => t.id !== draggedId)
+    // Remove the dragged tile and reclaim its space before splitting.
+    // Without reclamation, the source tile's area becomes an orphaned gap.
+    const withoutDragged = removeTilePreservingStructure(layout, draggedId, tabs, width, height)
     return splitTile(withoutDragged, zone.targetTileId, draggedId, direction)
   }, [tabs, containerSizeRef])
 }


### PR DESCRIPTION
## Summary
- **Split MIN_SIZE guard**: `splitTile()` now refuses to split when the resulting tiles would be smaller than MIN_SIZE (10%), preventing undersized tiles that pass validation but behave poorly during resize
- **Drag-split gap fix**: When dragging a tile to split another, the source tile's space is now reclaimed via `removeTilePreservingStructure` instead of leaving orphaned gaps
- **Consistent validation threshold**: `validateLayout` now uses `MIN_SIZE` (10) instead of a hardcoded 5 for minimum tile dimensions
- **Overlap correction**: `validateLayout` now resets to default layout when overlapping tiles are detected, instead of only logging a warning

## Test plan
- [ ] Split a tile that is already small (near 20% width/height) — verify the split is refused rather than creating undersized tiles
- [ ] Drag a tile from one position to split another tile — verify the original position's space is absorbed by neighbors
- [ ] Verify layouts with overlapping tiles are auto-corrected to default layout
- [ ] Verify normal split/drag/resize operations still work correctly

Task: @bug-layout
Spec: @tiled-layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)