### PR TITLE
fix: PTY backend switch and ANSI stripping bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out/
 *.log
 .DS_Store
 dist-build/
+.kspec/

--- a/src/main/app/ipc-handlers/pty.ts
+++ b/src/main/app/ipc-handlers/pty.ts
@@ -101,14 +101,33 @@ export function registerPtyHandlers(
   })
 
   ipcMain.handle('pty:set-backend', async (_, { id: oldId, backend: newBackend }: { id: string; backend: 'claude' | 'gemini' | 'codex' | 'opencode' | 'aider' }) => {
-    const process = ptyManager.getProcess(oldId)
-    if (!process) return
+    const proc = ptyManager.getProcess(oldId)
+    if (!proc) return
 
-    const { cwd, sessionId, backend: oldBackend } = process
+    const { cwd, sessionId, backend: oldBackend } = proc
     const effectiveSessionId = oldBackend !== newBackend ? undefined : sessionId
 
+    // Look up project settings so the new PTY inherits permissions and model
+    const workspace = sessionStore.getWorkspace()
+    const project = workspace.projects.find(p => p.path === cwd)
+    const globalSettings = sessionStore.getSettings()
+    const autoAcceptTools = project?.autoAcceptTools ?? globalSettings.autoAcceptTools
+    const permissionMode = project?.permissionMode ?? globalSettings.permissionMode
+
+    // Kill old PTY first, then spawn new one with error recovery
     ptyManager.kill(oldId)
-    const newId = ptyManager.spawn(cwd, effectiveSessionId, undefined, undefined, undefined, newBackend)
+
+    let newId: string
+    try {
+      newId = ptyManager.spawn(cwd, effectiveSessionId, autoAcceptTools, permissionMode, undefined, newBackend)
+    } catch (error: any) {
+      console.error('Failed to spawn new PTY during backend switch:', error)
+      // Clean up stale map entries from the killed PTY
+      ptyToProject.delete(oldId)
+      ptyToBackend.delete(oldId)
+      autoCloseSessions.delete(oldId)
+      throw new Error(`Failed to switch backend to ${newBackend}: ${error.message}`)
+    }
 
     const projectPath = ptyToProject.get(oldId)
     if (projectPath) {
@@ -118,17 +137,31 @@ export function registerPtyHandlers(
     ptyToBackend.set(newId, newBackend)
     ptyToBackend.delete(oldId)
 
+    // Transfer autoClose flag if the old session had it
+    if (autoCloseSessions.delete(oldId)) {
+      autoCloseSessions.add(newId)
+    }
+
     const mainWindow = getMainWindow()
 
     ptyManager.onData(newId, (data) => {
       maybeRespondToCursorPositionRequest(ptyManager, ptyToBackend, newId, data)
-      mainWindow?.webContents.send(`pty:data:${newId}`, data)
+      try {
+        mainWindow?.webContents.send(`pty:data:${newId}`, data)
+      } catch (e) {
+        console.error('IPC send failed', e)
+      }
     })
 
     ptyManager.onExit(newId, (code) => {
-      mainWindow?.webContents.send(`pty:exit:${newId}`, code)
+      try {
+        mainWindow?.webContents.send(`pty:exit:${newId}`, code)
+      } catch (e) {
+        console.error('IPC send failed', e)
+      }
       ptyToProject.delete(newId)
       ptyToBackend.delete(newId)
+      autoCloseSessions.delete(newId)
     })
 
     mainWindow?.webContents.send('pty:recreated', { oldId, newId, backend: newBackend })

--- a/src/main/pty-manager.ts
+++ b/src/main/pty-manager.ts
@@ -26,7 +26,13 @@ class OutputBuffer {
     this.partial = parts.pop() || ''
     for (const line of parts) {
       // Strip ANSI escape sequences for readability
-      const clean = line.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').replace(/\x1b\][^\x07]*\x07/g, '').trim()
+      // Strip all CSI sequences (including private modes like ?25h, ?1049h),
+      // OSC sequences, and single-character escape sequences (e.g. \x1b(B)
+      const clean = line
+        .replace(/\x1b\[[\x20-\x3f]*[\x40-\x7e]/g, '')  // CSI: covers standard + private mode sequences
+        .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, '')  // OSC: terminated by BEL or ST
+        .replace(/\x1b[()][A-Z0-9]/g, '')  // Character set selection (e.g. \x1b(B)
+        .trim()
       if (clean) {
         this.lines.push(clean)
         if (this.lines.length > OUTPUT_BUFFER_MAX_LINES) {


### PR DESCRIPTION
## Summary
- **Backend switch now inherits project settings** — `pty:set-backend` was calling `spawn()` with `undefined` for autoAcceptTools and permissionMode, losing all permission configuration on switch
- **Backend switch error handling** — if spawn fails after killing the old PTY, the error now propagates to the renderer instead of silently leaving the user with no terminal
- **autoCloseSessions transfer** — the auto-close flag is now moved from the old PTY ID to the new one during backend switch
- **ANSI stripping regex hardened** — OutputBuffer now strips private mode sequences (`\x1b[?25h`, `\x1b[?1049h`), character set escapes (`\x1b(B`), and OSC sequences with ST terminators

## Test plan
- [ ] Switch backends in a project with custom permission settings — verify new PTY respects them
- [ ] Trigger a backend switch to a non-existent backend — verify error surfaces in renderer
- [ ] Verify `readOutput()` returns clean text without ANSI artifacts (e.g. `?25h` leaking through)
- [ ] Normal PTY spawn/resize/kill lifecycle still works

Task: @bug-pty
Spec: @pty-lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)