### PR TITLE
fix: task adapter bugs — status mapping, daemon recovery, migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ out/
 *.log
 .DS_Store
 dist-build/
+.kspec/

--- a/src/main/ipc/kspec-handlers.ts
+++ b/src/main/ipc/kspec-handlers.ts
@@ -195,6 +195,13 @@ async function migrateBeadsToKspec(cwd: string): Promise<{ success: boolean; mig
           const beadsType = String(task.issue_type ?? task.type ?? 'task')
           const kspecType = beadsType === 'feature' ? 'task' : (['bug', 'task', 'epic'].includes(beadsType) ? beadsType : 'task')
 
+          // Map beads status to kspec status
+          const beadsStatus = String(task.status ?? 'open')
+          let kspecStatus: string | undefined
+          if (beadsStatus === 'in_progress') kspecStatus = 'in_progress'
+          else if (beadsStatus === 'closed') kspecStatus = 'completed'
+          // 'open' maps to 'pending' which is the default — no need to set
+
           const res = await fetch('http://localhost:3456/api/tasks', {
             method: 'POST',
             headers: {
@@ -203,9 +210,10 @@ async function migrateBeadsToKspec(cwd: string): Promise<{ success: boolean; mig
             },
             body: JSON.stringify({
               title: String(task.title ?? ''),
-              description: String(task.description ?? ''),
+              description: task.description ? String(task.description) : undefined,
               priority: kspecPriority,
               type: kspecType,
+              status: kspecStatus,
               tags: [`migrated-from:${String(task.id ?? '')}`]
             })
           })

--- a/src/renderer/components/beads/adapters/kspec-adapter.ts
+++ b/src/renderer/components/beads/adapters/kspec-adapter.ts
@@ -26,6 +26,8 @@ function headers(cwd: string): HeadersInit {
 
 // Shared flag so API failures can signal the adapter to re-check daemon
 let _daemonEnsuredFlag = true
+// Last project dir we ensured daemon for — reset flag on project switch
+let _daemonEnsuredForCwd: string | null = null
 
 async function api<T>(method: string, path: string, cwd: string, body?: unknown): Promise<T> {
   const opts: RequestInit = {
@@ -90,15 +92,20 @@ export class KspecAdapter implements TaskAdapter {
   readonly kind = 'kspec' as const
 
   private async ensureDaemon(cwd: string): Promise<boolean> {
+    // Reset flag when switching projects so we re-verify daemon for new cwd
+    if (_daemonEnsuredForCwd !== null && _daemonEnsuredForCwd !== cwd) {
+      _daemonEnsuredFlag = false
+    }
+
     // Quick health check first
     try {
       const res = await fetch(`${API_BASE}/api/health`)
-      if (res.ok) { _daemonEnsuredFlag = true; return true }
+      if (res.ok) { _daemonEnsuredFlag = true; _daemonEnsuredForCwd = cwd; return true }
     } catch { /* daemon not running */ }
 
     // Start daemon via IPC (always attempt if health check failed)
     const result = await window.electronAPI?.kspecEnsureDaemon?.(cwd)
-    if (result?.success) { _daemonEnsuredFlag = true; return true }
+    if (result?.success) { _daemonEnsuredFlag = true; _daemonEnsuredForCwd = cwd; return true }
     return false
   }
 
@@ -221,6 +228,7 @@ export class KspecAdapter implements TaskAdapter {
   private wsCallbacks: Set<(data: { cwd: string }) => void> = new Set()
   private watchedCwd: string | null = null
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private reconnectDelay = 1000
   private watching = false
 
   watch(cwd: string): void {
@@ -231,6 +239,7 @@ export class KspecAdapter implements TaskAdapter {
     }
     this.watching = true
     this.watchedCwd = cwd
+    this.reconnectDelay = 1000
     this.connectWs(cwd)
   }
 
@@ -246,11 +255,15 @@ export class KspecAdapter implements TaskAdapter {
           }
         } catch { /* ignore parse errors */ }
       }
+      this.ws.onopen = () => {
+        this.reconnectDelay = 1000 // Reset backoff on successful connection
+      }
       this.ws.onclose = () => {
         this.ws = null
-        // Auto-reconnect if still watching this project
+        // Auto-reconnect with exponential backoff (cap at 30s)
         if (this.watching && this.watchedCwd === cwd) {
-          this.reconnectTimer = setTimeout(() => this.connectWs(cwd), 3000)
+          this.reconnectTimer = setTimeout(() => this.connectWs(cwd), this.reconnectDelay)
+          this.reconnectDelay = Math.min(this.reconnectDelay * 2, 30000)
         }
       }
       this.ws.onerror = () => {

--- a/src/renderer/components/beads/adapters/kspec-adapter.ts
+++ b/src/renderer/components/beads/adapters/kspec-adapter.ts
@@ -24,13 +24,23 @@ function headers(cwd: string): HeadersInit {
   }
 }
 
+// Shared flag so API failures can signal the adapter to re-check daemon
+let _daemonEnsuredFlag = true
+
 async function api<T>(method: string, path: string, cwd: string, body?: unknown): Promise<T> {
   const opts: RequestInit = {
     method,
     headers: headers(cwd)
   }
   if (body) opts.body = JSON.stringify(body)
-  const res = await fetch(`${API_BASE}${path}`, opts)
+  let res: Response
+  try {
+    res = await fetch(`${API_BASE}${path}`, opts)
+  } catch (e) {
+    // Network error — daemon likely crashed, reset ensured flag
+    _daemonEnsuredFlag = false
+    throw e
+  }
   if (!res.ok) {
     const text = await res.text()
     throw new Error(text || `HTTP ${res.status}`)
@@ -78,20 +88,17 @@ function toUnified(raw: Record<string, unknown>): UnifiedTask {
 
 export class KspecAdapter implements TaskAdapter {
   readonly kind = 'kspec' as const
-  private daemonEnsured = false
 
   private async ensureDaemon(cwd: string): Promise<boolean> {
     // Quick health check first
     try {
       const res = await fetch(`${API_BASE}/api/health`)
-      if (res.ok) { this.daemonEnsured = true; return true }
+      if (res.ok) { _daemonEnsuredFlag = true; return true }
     } catch { /* daemon not running */ }
 
-    // Start daemon via IPC
-    if (!this.daemonEnsured) {
-      const result = await window.electronAPI?.kspecEnsureDaemon?.(cwd)
-      if (result?.success) { this.daemonEnsured = true; return true }
-    }
+    // Start daemon via IPC (always attempt if health check failed)
+    const result = await window.electronAPI?.kspecEnsureDaemon?.(cwd)
+    if (result?.success) { _daemonEnsuredFlag = true; return true }
     return false
   }
 
@@ -183,7 +190,11 @@ export class KspecAdapter implements TaskAdapter {
 
   async update(cwd: string, taskId: string, params: UpdateTaskParams): Promise<{ success: boolean; error?: string }> {
     try {
-      await api('PATCH', `/api/tasks/${encodeURIComponent(taskId)}`, cwd, params)
+      // Map unified status names back to kspec native status names
+      const body = { ...params }
+      if (body.status === 'open') body.status = 'pending' as TaskStatus
+      if (body.status === 'closed') body.status = 'completed' as TaskStatus
+      await api('PATCH', `/api/tasks/${encodeURIComponent(taskId)}`, cwd, body)
       return { success: true }
     } catch (e) {
       return { success: false, error: String(e) }
@@ -194,15 +205,36 @@ export class KspecAdapter implements TaskAdapter {
     switch (currentStatus) {
       case 'open': return this.start(cwd, taskId)
       case 'in_progress': return this.complete(cwd, taskId)
-      default: return this.update(cwd, taskId, { status: 'open' })
+      default:
+        // Kspec uses 'pending' internally — 'open' is only the unified status
+        try {
+          await api('PATCH', `/api/tasks/${encodeURIComponent(taskId)}`, cwd, { status: 'pending' })
+          return { success: true }
+        } catch (e) {
+          return { success: false, error: String(e) }
+        }
     }
   }
 
   // Kspec uses WebSocket for live updates instead of file watching
   private ws: WebSocket | null = null
   private wsCallbacks: Set<(data: { cwd: string }) => void> = new Set()
+  private watchedCwd: string | null = null
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private watching = false
 
   watch(cwd: string): void {
+    // If switching projects, close old connection first
+    if (this.ws && this.watchedCwd !== cwd) {
+      this.ws.close()
+      this.ws = null
+    }
+    this.watching = true
+    this.watchedCwd = cwd
+    this.connectWs(cwd)
+  }
+
+  private connectWs(cwd: string): void {
     if (this.ws) return
     try {
       this.ws = new WebSocket(`ws://localhost:${DAEMON_PORT}/ws?project=${encodeURIComponent(cwd)}`)
@@ -214,11 +246,26 @@ export class KspecAdapter implements TaskAdapter {
           }
         } catch { /* ignore parse errors */ }
       }
-      this.ws.onclose = () => { this.ws = null }
-    } catch { /* daemon not running */ }
+      this.ws.onclose = () => {
+        this.ws = null
+        // Auto-reconnect if still watching this project
+        if (this.watching && this.watchedCwd === cwd) {
+          this.reconnectTimer = setTimeout(() => this.connectWs(cwd), 3000)
+        }
+      }
+      this.ws.onerror = () => {
+        // onclose will fire after onerror, triggering reconnect
+      }
+    } catch { /* daemon not running — reconnect will retry */ }
   }
 
   unwatch(_cwd: string): void {
+    this.watching = false
+    this.watchedCwd = null
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
     this.ws?.close()
     this.ws = null
   }

--- a/src/renderer/components/beads/useBeadsTasks.ts
+++ b/src/renderer/components/beads/useBeadsTasks.ts
@@ -334,7 +334,9 @@ export function useBeadsTasks({
     tasksCache.set(projectPath, updatedTasks)
 
     try {
-      const result = await adapter.update(projectPath, taskId, { status: nextStatus as UnifiedTask['status'] })
+      // Use adapter.cycleStatus() which knows the correct lifecycle endpoints
+      // (e.g., kspec uses /start and /complete instead of generic PATCH)
+      const result = await adapter.cycleStatus(projectPath, taskId, currentStatus as UnifiedTask['status'])
       if (!result.success) {
         setTasks(previousTasks)
         tasksCache.set(projectPath, previousTasks)


### PR DESCRIPTION
## Summary
- **handleCycleStatus bypasses adapter.cycleStatus()**: Was calling `adapter.update()` directly, skipping kspec's lifecycle endpoints (`/start`, `/complete`). Now routes through `adapter.cycleStatus()`.
- **Status name mismatch**: Kspec uses `pending`/`completed` internally but the adapter was sending unified names `open`/`closed`. Added reverse mapping in `update()` and `cycleStatus()`.
- **Daemon crash recovery**: `daemonEnsured` flag was set once and never reset on failure. Now resets on network errors so the adapter retries daemon startup.
- **WebSocket reconnection**: Watcher WebSocket went dead after daemon restart. Added auto-reconnect with 3s backoff and proper cleanup on project switch.
- **Migration data loss**: Beads-to-kspec migration was losing task status (all became `pending`). Now preserves `in_progress` and `closed` statuses.
- **Empty description in migration**: Was sending `""` instead of `undefined` for tasks without descriptions.

## Test plan
- [ ] Cycle task status in kspec panel — verify open→in_progress→closed→open works
- [ ] Kill kspec daemon while panel is open — verify it recovers and reconnects
- [ ] Switch between projects with task panels — verify WebSocket connects to correct project
- [ ] Test beads→kspec migration with tasks in various statuses

Task: @bug-tasks
Spec: @task-adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)