### PR TITLE
fix: connectivity bug audit — port fallback, rate limit, CORS, WS cleanup

### DIFF
--- a/src/main/app/ipc-handlers/pty.ts
+++ b/src/main/app/ipc-handlers/pty.ts
@@ -80,13 +80,24 @@ export function registerPtyHandlers(
         pendingApiPrompts.delete(cwd)
         if (pending.autoClose) autoCloseSessions.add(id)
         setTimeout(() => {
-          ptyManager.write(id, pending.prompt + '\n')
-          pending.resolve({ success: true, message: 'Prompt sent to new terminal', sessionCreated: true })
+          // Verify PTY still exists before writing (race condition guard)
+          if (ptyManager.getProcess(id)) {
+            ptyManager.write(id, pending.prompt + '\n')
+            pending.resolve({ success: true, message: 'Prompt sent to new terminal', sessionCreated: true })
+          } else {
+            pending.resolve({ success: false, error: 'Terminal exited before prompt could be sent' })
+          }
         }, 4000)
       }
 
       return id
     } catch (error: any) {
+      // Resolve pending prompt immediately on spawn failure instead of waiting for 30s timeout
+      const pending = pendingApiPrompts.get(cwd)
+      if (pending) {
+        pendingApiPrompts.delete(cwd)
+        pending.resolve({ success: false, error: `Failed to start terminal: ${error.message}` })
+      }
       console.error('Failed to spawn PTY:', error)
       throw new Error(`Failed to start Claude: ${error.message}`)
     }

--- a/src/main/mobile-security/auth-rate-limit.ts
+++ b/src/main/mobile-security/auth-rate-limit.ts
@@ -33,8 +33,8 @@ export function checkRateLimit(ip: string): { allowed: boolean; retryAfter?: num
     }
   }
 
-  // Check if window has expired - reset if so
-  if (now - entry.lastAttempt > RATE_LIMIT_WINDOW_MS) {
+  // Block expired or window expired — reset so user gets fresh attempts
+  if ((entry.blockedUntil && entry.blockedUntil <= now) || now - entry.lastAttempt > RATE_LIMIT_WINDOW_MS) {
     rateLimitStore.delete(ip)
     return { allowed: true }
   }

--- a/src/main/mobile-server/index.ts
+++ b/src/main/mobile-server/index.ts
@@ -213,7 +213,7 @@ export class MobileServer {
   }
 
   private broadcastPtyExit(ptyId: string, code: number): void {
-    wsBroadcastPtyExit(ptyId, code, this.ptyStreams)
+    wsBroadcastPtyExit(ptyId, code, this.ptyStreams, this.terminalSubscriptions)
   }
 
   // Service handlers

--- a/src/main/mobile-server/middleware.ts
+++ b/src/main/mobile-server/middleware.ts
@@ -31,26 +31,35 @@ export function setupCorsMiddleware(app: Express): void {
         return callback(null, true)
       }
 
+      // Parse origin to extract hostname for safe validation
+      let hostname: string
+      try {
+        hostname = new URL(origin).hostname
+      } catch {
+        log('CORS blocked malformed origin', { origin })
+        return callback(new Error('CORS not allowed for this origin'))
+      }
+
       // Allow localhost variants
-      if (origin.includes('localhost') || origin.includes('127.0.0.1')) {
+      if (hostname === 'localhost' || hostname === '127.0.0.1') {
         return callback(null, true)
       }
 
       // Allow local network IP ranges (RFC 1918)
       // 10.x.x.x, 192.168.x.x, 172.16-31.x.x
-      const localNetworkPattern = /^https?:\/\/(10\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+)(:\d+)?/
-      if (localNetworkPattern.test(origin)) {
+      const localNetworkPattern = /^(10\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+)$/
+      if (localNetworkPattern.test(hostname)) {
         return callback(null, true)
       }
 
       // Allow Tailscale CGNAT range (100.64.0.0 - 100.127.255.255)
-      const tailscaleCgnatPattern = /^https?:\/\/100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d+\.\d+(:\d+)?/
-      if (tailscaleCgnatPattern.test(origin)) {
+      const tailscaleCgnatPattern = /^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\.\d+\.\d+$/
+      if (tailscaleCgnatPattern.test(hostname)) {
         return callback(null, true)
       }
 
       // Allow Tailscale MagicDNS hostnames (*.ts.net)
-      if (origin.includes('.ts.net')) {
+      if (hostname.endsWith('.ts.net')) {
         return callback(null, true)
       }
 

--- a/src/main/mobile-server/websocket-manager.ts
+++ b/src/main/mobile-server/websocket-manager.ts
@@ -318,20 +318,25 @@ export function broadcastPtyData(
 export function broadcastPtyExit(
   ptyId: string,
   code: number,
-  ptyStreams: Map<string, Set<WebSocket>>
+  ptyStreams: Map<string, Set<WebSocket>>,
+  terminalSubscriptions?: Map<string, Set<WebSocket>>
 ): void {
   const streams = ptyStreams.get(ptyId)
-  if (!streams || streams.size === 0) return
+  if (streams && streams.size > 0) {
+    const message = JSON.stringify({
+      type: 'exit',
+      code
+    })
 
-  const message = JSON.stringify({
-    type: 'exit',
-    code
-  })
+    streams.forEach(ws => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(message)
+        ws.close(1000, 'PTY exited')
+      }
+    })
+  }
 
-  streams.forEach(ws => {
-    if (ws.readyState === WebSocket.OPEN) {
-      ws.send(message)
-      ws.close(1000, 'PTY exited')
-    }
-  })
+  // Clean up stale subscriptions for this PTY
+  ptyStreams.delete(ptyId)
+  terminalSubscriptions?.delete(ptyId)
 }

--- a/src/main/orchestrator-api.ts
+++ b/src/main/orchestrator-api.ts
@@ -2,11 +2,13 @@ import * as http from 'http'
 import type { PtyManager } from './pty-manager.js'
 
 const ORCHESTRATOR_PORT = 19836
+const MAX_PORT_RETRIES = 5
 
 export class OrchestratorApi {
   private server: http.Server | null = null
   private ptyManager: PtyManager
   private ptyToProject: Map<string, string>
+  private activePort: number = ORCHESTRATOR_PORT
 
   constructor(ptyManager: PtyManager, ptyToProject: Map<string, string>) {
     this.ptyManager = ptyManager
@@ -15,6 +17,8 @@ export class OrchestratorApi {
 
   start(): void {
     if (this.server) return
+
+    this.activePort = ORCHESTRATOR_PORT
 
     this.server = http.createServer((req, res) => {
       res.setHeader('Content-Type', 'application/json')
@@ -27,7 +31,7 @@ export class OrchestratorApi {
         return
       }
 
-      const url = new URL(req.url || '/', `http://localhost:${ORCHESTRATOR_PORT}`)
+      const url = new URL(req.url || '/', `http://localhost:${this.activePort}`)
       const path = url.pathname
 
       // Match: /sessions/:id/output or /sessions/:id/input
@@ -46,14 +50,27 @@ export class OrchestratorApi {
       }
     })
 
-    this.server.listen(ORCHESTRATOR_PORT, '127.0.0.1', () => {
-      console.log(`[Orchestrator] API server started on port ${ORCHESTRATOR_PORT}`)
+    this.tryListen(this.activePort)
+  }
+
+  private tryListen(port: number): void {
+    const retryCount = port - ORCHESTRATOR_PORT
+    if (retryCount >= MAX_PORT_RETRIES) {
+      console.error(`[Orchestrator] Failed to bind after ${MAX_PORT_RETRIES} attempts (ports ${ORCHESTRATOR_PORT}-${port - 1})`)
+      this.server?.close()
+      this.server = null
+      return
+    }
+
+    this.server!.listen(port, '127.0.0.1', () => {
+      this.activePort = port
+      console.log(`[Orchestrator] API server started on port ${port}`)
     })
 
-    this.server.on('error', (e: NodeJS.ErrnoException) => {
+    this.server!.once('error', (e: NodeJS.ErrnoException) => {
       if (e.code === 'EADDRINUSE') {
-        console.warn(`[Orchestrator] Port ${ORCHESTRATOR_PORT} in use, trying ${ORCHESTRATOR_PORT + 1}`)
-        this.server?.listen(ORCHESTRATOR_PORT + 1, '127.0.0.1')
+        console.warn(`[Orchestrator] Port ${port} in use, trying ${port + 1}`)
+        this.tryListen(port + 1)
       } else {
         console.error('[Orchestrator] API server error:', e.message)
       }


### PR DESCRIPTION
## Summary
- Orchestrator API: Port fallback with bounded retries (max 5 ports)
- CORS validation: Parse origin hostname properly to prevent bypass
- Rate limit: Expired blocks now properly reset
- WebSocket cleanup: PTY exit cleans stale subscriptions; kspec auto-reconnect
- PTY race guards: Verify PTY exists before writing; resolve on spawn failure
- Kspec adapter: Daemon recovery, status mapping, cycleStatus lifecycle
- Type cleanup: Remove unused openvoice from TTS union types